### PR TITLE
Fixed confine so it would work as expected (cannot be inside set code bl...

### DIFF
--- a/lib/facter/profiles.rb
+++ b/lib/facter/profiles.rb
@@ -1,6 +1,6 @@
 Facter.add(:profiles) do
+  confine :kernel => "Darwin"
   setcode do
-    confine :kernel => "Darwin"
     profiles = %x{/usr/bin/profiles -P | /usr/bin/grep profileIdentifier | awk '{ print $4 }'}.split("\n")
     profiles.join(',')
   end


### PR DESCRIPTION
When the confine was inside the setcode block, the fact would throw errors on non-darwin OSes.
