### PR TITLE
Confining fact to versions of OS X that support configuration profiles. ...

### DIFF
--- a/lib/facter/profiles.rb
+++ b/lib/facter/profiles.rb
@@ -1,5 +1,6 @@
 Facter.add(:profiles) do
   confine :kernel => "Darwin"
+  confine :macosx_productversion_major => %w{10.7 10.8 10.9}
   setcode do
     profiles = %x{/usr/bin/profiles -P | /usr/bin/grep profileIdentifier | awk '{ print $4 }'}.split("\n")
     profiles.join(',')


### PR DESCRIPTION
.../usr/bin/profiles on 10.6 and below is a samba utility to change windows registry files.
