### PR TITLE
prevent false positives

### DIFF
--- a/lib/puppet/provider/profile_manager/osx.rb
+++ b/lib/puppet/provider/profile_manager/osx.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:profile_manager).provide :osx do
   end
 
   def exists?
-    `/usr/bin/profiles -P | /usr/bin/grep '#{resource[:name]}'`
+    `/usr/bin/profiles -P | /usr/bin/awk '{ print $4 }' | /usr/bin/grep -x '#{resource[:name]}'`
     if $? == 0
       return true
     else


### PR DESCRIPTION
Changed the def exists? to better guard against false positives.  It will grab an exact match for the profile name instead of grabbing similar profile names that may not be correct.
